### PR TITLE
Add language field to all API call

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,16 @@ function getParams(self, steamObj, requiredParams, optionalParams) {
         }
 
     }
+    
+    // Add language  field to all API call
+    try {
+        if (paramObj["language"] === undefined {
+            paramObj["language"] = get(self, steamObj, "language");
+        }
+    } catch (e) {
+
+    }
+    
     return paramObj;
 }
 

--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ function getParams(self, steamObj, requiredParams, optionalParams) {
     
     // Add language  field to all API call
     try {
-        if (paramObj["language"] === undefined {
+        if (paramObj["language"] === undefined) {
             paramObj["language"] = get(self, steamObj, "language");
         }
     } catch (e) {


### PR DESCRIPTION
Language parameter is used in many API methods (e.g `getLeagueListing`) but the retrieved API documents does not have them in the optional parameteres. That means with current state of `getParams`, even if we pass `language` into `steamObj`, it will be discarded most of the time. 

Without the `language` field, the data return won't be in readable state. Thus I proposed add the language parameter to all method calls (it doesn't cause unnecessary side-effect anyway).
